### PR TITLE
Add Vue project scaffold with Element Plus

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Vue</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "am-erp-vue",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.0.0",
+    "element-plus": "^2.0.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-vue": "^4.0.0"
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <div id="app">
+    <h1>Hello Element Plus</h1>
+    <el-button type="primary">Primary Button</el-button>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style>
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,9 @@
+import { createApp } from 'vue'
+import ElementPlus from 'element-plus'
+import 'element-plus/dist/index.css'
+
+import App from './App.vue'
+
+const app = createApp(App)
+app.use(ElementPlus)
+app.mount('#app')

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+})


### PR DESCRIPTION
## Summary
- scaffold a simple Vue 3 app with Vite config
- include Element Plus setup and an `<el-button>` sample
- define `dev`, `build`, and `preview` scripts in **package.json**

## Testing
- `npm create vite@latest . -- --template vue` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*
- `npm install element-plus` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68555e8bd6cc832ab39f09260f95376d