### PR TITLE
Add vue-i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository demonstrates a simple Vue-based ERP demo.
 
+## Internationalization
+
+This project now includes basic i18n setup using [vue-i18n](https://vue-i18n.intlify.dev/).
+Translation files live under `src/locales`.
+
 ## Prerequisites
 
 - Node.js **16** or later is recommended.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "vue": "^3.0.0",
-    "element-plus": "^2.0.0"
+    "element-plus": "^2.0.0",
+    "vue-i18n": "^9.2.2"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <h1>Hello Element Plus</h1>
+    <h1>{{ $t('message.hello') }}</h1>
     <el-button type="primary">Primary Button</el-button>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,5 @@
+{
+  "message": {
+    "hello": "Hello World"
+  }
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,5 @@
+{
+  "message": {
+    "hello": "Bonjour le monde"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,17 @@
 import { createApp } from 'vue'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+import fr from './locales/fr.json'
 
 import App from './App.vue'
 
 const app = createApp(App)
+const i18n = createI18n({
+  locale: 'en',
+  messages: { en, fr }
+})
 app.use(ElementPlus)
+app.use(i18n)
 app.mount('#app')


### PR DESCRIPTION
## Summary
- install `vue-i18n`
- add sample locale files
- configure i18n in `main.js`
- display translated text in `App.vue`
- mention i18n in README

## Testing
- `npm run build` *(fails: vite not found as dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68564357c804832aba8fee29cab1470e