### PR TITLE
Add Vitest and example component test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ npm run dev
 
 This will launch the local server, typically at `http://localhost:5173`.
 
+## Testing
+
+Run unit tests with:
+
+```bash
+npm run test
+```
+
 ## Usage Example
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "vue": "^3.0.0",
@@ -13,6 +14,9 @@
   },
   "devDependencies": {
     "vite": "^4.0.0",
-    "@vitejs/plugin-vue": "^4.0.0"
+    "@vitejs/plugin-vue": "^4.0.0",
+    "vitest": "^0.34.0",
+    "@vue/test-utils": "^2.4.1",
+    "jsdom": "^21.1.0"
   }
 }

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="hello">{{ msg }}</div>
+</template>
+
+<script setup>
+defineProps({
+  msg: {
+    type: String,
+    default: 'Hello World'
+  }
+})
+</script>
+
+<style scoped>
+.hello {
+  color: #42b983;
+}
+</style>

--- a/src/components/__tests__/HelloWorld.test.js
+++ b/src/components/__tests__/HelloWorld.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import HelloWorld from '../HelloWorld.vue'
+
+describe('HelloWorld', () => {
+  it('renders message', () => {
+    const wrapper = mount(HelloWorld, { props: { msg: 'Test Message' } })
+    expect(wrapper.text()).toContain('Test Message')
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,8 @@ import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
   plugins: [vue()],
+  test: {
+    globals: true,
+    environment: 'jsdom'
+  }
 })


### PR DESCRIPTION
## Summary
- add HelloWorld component
- set up Vitest and Vue Test Utils
- provide a basic unit test for HelloWorld
- document test command

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685643567b18832a93bf7b5b0c800a65