### PR TITLE
Add Pinia store integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ $ npm run dev
 ```
 
 A screenshot or more detailed demo may be added in the future.
+
+## State Management
+
+This project uses [Pinia](https://pinia.vuejs.org/) for state management. An example
+store is located in `src/store/counter.js`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "vue": "^3.0.0",
-    "element-plus": "^2.0.0"
+    "element-plus": "^2.0.0",
+    "pinia": "^2.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,13 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
 
 import App from './App.vue'
 
 const app = createApp(App)
+
+app.use(createPinia())
 app.use(ElementPlus)
+
 app.mount('#app')

--- a/src/store/counter.js
+++ b/src/store/counter.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+
+export const useCounterStore = defineStore('counter', {
+  state: () => ({
+    count: 0
+  }),
+  actions: {
+    increment() {
+      this.count++
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- set up Pinia for state management
- create example counter store
- register Pinia in the Vue app
- document Pinia usage in the README

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm run build` *(fails: vite not found because dependencies weren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856435182c4832aa1b6caf75b061ae4