### PR TITLE
Add login and register pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Domain modules live under `src/modules`. Each module contains an
 ```
 src/modules/user/index.vue
 src/modules/product/index.vue
+src/modules/Login.vue
+src/modules/Register.vue
 ```
 
 You can extend these components with actual business logic.

--- a/src/modules/Login.vue
+++ b/src/modules/Login.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="login-page">
+    <el-form @submit.prevent="onSubmit" :model="form" class="login-form">
+      <el-form-item label="Username">
+        <el-input v-model="form.username" autocomplete="off" />
+      </el-form-item>
+      <el-form-item label="Password">
+        <el-input v-model="form.password" type="password" autocomplete="off" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" native-type="submit">Login</el-button>
+      </el-form-item>
+    </el-form>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+
+const form = reactive({
+  username: '',
+  password: ''
+})
+
+const onSubmit = () => {
+  console.log('login', form)
+  // TODO: implement login logic
+}
+</script>
+
+<style scoped>
+.login-page {
+  max-width: 400px;
+  margin: 2rem auto;
+}
+</style>

--- a/src/modules/Register.vue
+++ b/src/modules/Register.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="register-page">
+    <el-form @submit.prevent="onSubmit" :model="form" class="register-form">
+      <el-form-item label="Username">
+        <el-input v-model="form.username" autocomplete="off" />
+      </el-form-item>
+      <el-form-item label="Password">
+        <el-input v-model="form.password" type="password" autocomplete="off" />
+      </el-form-item>
+      <el-form-item label="Confirm">
+        <el-input v-model="form.confirm" type="password" autocomplete="off" />
+      </el-form-item>
+      <el-form-item>
+        <el-button type="primary" native-type="submit">Register</el-button>
+      </el-form-item>
+    </el-form>
+  </div>
+</template>
+
+<script setup>
+import { reactive } from 'vue'
+
+const form = reactive({
+  username: '',
+  password: '',
+  confirm: ''
+})
+
+const onSubmit = () => {
+  console.log('register', form)
+  // TODO: implement registration logic
+}
+</script>
+
+<style scoped>
+.register-page {
+  max-width: 400px;
+  margin: 2rem auto;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,16 @@ const routes = [
     path: '/about',
     name: 'About',
     component: () => import('../modules/About.vue')
+  },
+  {
+    path: '/login',
+    name: 'Login',
+    component: () => import('../modules/Login.vue')
+  },
+  {
+    path: '/register',
+    name: 'Register',
+    component: () => import('../modules/Register.vue')
   }
 ]
 


### PR DESCRIPTION
## Summary
- create Login and Register modules with Element Plus forms
- register new routes for `/login` and `/register`
- document new modules in README

## Testing
- `npm run lint` *(fails: config object is using the "env" key)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564efd2da0832aa345a7aef30d86e4